### PR TITLE
Fixed typo on README and added links to plugins page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you have multiple servers in your cluster, you'll also need to set <code>conf
 
 ## Plugins
 
-We now support installing plugins via manifests!  You just need to add the following to your manifest:
+We now support installing [plugins](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-plugins.html) via manifests!  You just need to add the following to your manifest:
 
 <pre><code>recipe :elasticsearch_plugins
   


### PR DESCRIPTION
I noticed a typo on the README so I fixed it. I also added a link to the Elasticsearch documentation page about plugins, mostly for the convenience of reading about Elasticsearch plugins as well as having a list of useful plugins, as well.

I'm also doing this because @pengwynn offered an @atom invite for helping with open source projects :smile_cat: 
